### PR TITLE
Fetch pull-request refs from origin

### DIFF
--- a/git_buildpackage
+++ b/git_buildpackage
@@ -121,6 +121,9 @@ def fetch_upstream(url, revision, out_dir):
 
         safe_run(['git', 'clone', '--no-checkout', url, clone_dir],
                  cwd=out_dir, interactive=sys.stdout.isatty())
+        safe_run(['git', 'fetch', origin,
+                  'refs/pull-requests/*:refs/remotes/origin/pull-requests/*'],
+                 cwd=out_dir, interactive=sys.stdout.isatty())
 #        safe_run(['git', 'submodule', 'update', '--init', '--recursive'],
 #                 cwd=clone_dir)
     else:


### PR DESCRIPTION
Fetch the pull-request refs from the origin repository that stash
creates but doesn't export during a clone.